### PR TITLE
잘못된 도메인 정보 바로잡기

### DIFF
--- a/src/test/java/com/fast/projectboard/repository/JpaRepositoryTest.java
+++ b/src/test/java/com/fast/projectboard/repository/JpaRepositoryTest.java
@@ -50,7 +50,7 @@ class JpaRepositoryTest {
     void givenTestData_whenInserting_thenWorksFine(){
         // Given
         long previousCount = articleRepository.count();
-        UserAccount userAccount = userAccountRepository.save(UserAccount.of("uno", "pw", null, null, null));
+        UserAccount userAccount = userAccountRepository.save(UserAccount.of("newUno", "pw", null, null, null));
         Article article = Article.of(userAccount, "new article", "new content", "#spring");
 
         // When


### PR DESCRIPTION
회원 계정의 user_id에 UK 적용 완료

This closes #29 